### PR TITLE
fix: convert chunk size to x,y,z order - #19

### DIFF
--- a/src/cryo_et_neuroglancer/write_segmentation.py
+++ b/src/cryo_et_neuroglancer/write_segmentation.py
@@ -27,9 +27,9 @@ def _create_metadata(
         "num_channels": 1,
         "scales": [
             {
-                "chunk_sizes": [chunk_size],
+                "chunk_sizes": [chunk_size[::-1]],
                 "encoding": "compressed_segmentation",
-                "compressed_segmentation_block_size": block_size,
+                "compressed_segmentation_block_size": block_size[::-1],
                 "resolution": resolution,
                 "key": data_directory,
                 "size": data_size[


### PR DESCRIPTION
Should solve #19. The issue was that the chunk size was being output to the metadata in `Z, Y, X` order, but neuroglancer was expecting the chunk size to be in `X, Y, Z` order. Have reversed the chunk size and block size to be in `X, Y, Z` order accordingly.